### PR TITLE
Mermaid-cli arguments option and flexible HTML detection

### DIFF
--- a/mkdocs_with_pdf/drivers/headless_chrome.py
+++ b/mkdocs_with_pdf/drivers/headless_chrome.py
@@ -11,25 +11,29 @@ class HeadlessChromeDriver(object):
     """ 'Headless Chrome' executor """
 
     @classmethod
-    def setup(self, program_path: str, logger: Logger):
+    def setup(self, program_path: str, mermaid_args: str, logger: Logger):
         if not which(program_path):
             raise RuntimeError(
                 'No such `Headless Chrome` program or not executable'
                 + f': "{program_path}".')
-        return self(program_path, logger)
+        return self(program_path, mermaid_args, logger)
 
-    def __init__(self, program_path: str, logger: Logger):
+    def __init__(self, program_path: str, mermaid_args: str, logger: Logger):
         self._program_path = program_path
+        self.mermaid_args = mermaid_args
         self._logger = logger
 
     def render(self, html: str, temporary_directory: pathlib.Path) -> str:
         try:
-            mermaid_regex = r'<pre><code class="language-mermaid">(.*?)</code></pre>'
-            mermaid_matches = re.findall(mermaid_regex, html, flags=re.DOTALL)
+            mermaid_regex = re.compile(r'<(\w*?[^>]*)(><[^>]*?|[^>]*?)class="(language-)?mermaid">(<[^>]*?>)?(?P<code>.*?)(<\/[^>]*?>)?<\/\1>', flags=re.DOTALL)
+            mermaid_matches = mermaid_regex.finditer(html)
 
+            i = 0
             # Convert each Mermaid diagram to an image.
-            for i, mermaid_code in enumerate(mermaid_matches):
+            for mermaid_block in mermaid_matches:
+                i += 1
                 self._logger.info(f"Converting mermaid diagram {i}")
+                mermaid_code = mermaid_block.group("code")
 
                 # Create a temporary file to hold the Mermaid code.
                 mermaid_file_path = temporary_directory / f"diagram_{i + 1}.mmd"
@@ -38,18 +42,26 @@ class HeadlessChromeDriver(object):
                     mermaid_file.write(mermaid_code_unescaped.encode("utf-8"))
 
                 # Create a filename for the image.
-                image_file_path = temporary_directory / f"diagram_{i + 1}.png"
+                image_file_path = temporary_directory / f"diagram_{i}.png"
 
                 # Convert the Mermaid diagram to an image using mmdc.
-                command = f"mmdc -i {mermaid_file_path} -o {image_file_path} -b transparent -t dark --scale 4 --quiet"
+                command = f"mmdc -i {mermaid_file_path} -o {image_file_path} {self.mermaid_args}"
+
+                # suppress sub-process chatter when using '--quiet'
+                if self.mermaid_args.find('--quiet') > -1 or self.mermaid_args.find(' -q ') > -1 or self.mermaid_args.endswith(' -q'):
+                    command += " >/dev/null 2>&1"
 
                 os.system(command)
 
-                # Replace the Mermaid code with the image in the HTML string.
-                image_html = f'<img src="file://{image_file_path}" alt="Mermaid diagram {i+1}">'
-                html = html.replace(f'<pre><code class="language-mermaid">{mermaid_code}</code></pre>', image_html)
+                if not os.path.exists(image_file_path):
+                    self._logger.warning(f"Error: Failed to generate mermaid diagram {i}")
+                else:
+                    # Replace the Mermaid code with the image in the HTML string.
+                    image_html = f'<img src="file://{image_file_path}" alt="Mermaid diagram {i}">'
+                    html = html.replace(mermaid_block.group(0),
+                                        mermaid_block.group(0).replace(mermaid_code, image_html))
 
-            self._logger.info(f"Post mermaid translation: {html}")
+            self._logger.debug(f"Post mermaid translation: {html}")
             with open(temporary_directory / "post_mermaid_translation.html", "wb") as temp:
                 temp.write(html.encode('utf-8'))
 
@@ -66,7 +78,7 @@ class HeadlessChromeDriver(object):
                         '--dump-dom',
                         temp.name], stdout=PIPE) as chrome:
                 chrome_output = chrome.stdout.read().decode('utf-8')
-                self._logger.info(f"Post chrome translation: {chrome_output}")
+                self._logger.debug(f"Post chrome translation: {chrome_output}")
                 return chrome_output
 
         except Exception as e:

--- a/mkdocs_with_pdf/drivers/headless_chrome.py
+++ b/mkdocs_with_pdf/drivers/headless_chrome.py
@@ -25,7 +25,7 @@ class HeadlessChromeDriver(object):
 
     def render(self, html: str, temporary_directory: pathlib.Path) -> str:
         try:
-            mermaid_regex = re.compile(r'<(\w*?[^>]*)(><[^>]*?|[^>]*?)class="(language-)?mermaid">(<[^>]*?>)?(?P<code>.*?)(<\/[^>]*?>)?<\/\1>', flags=re.DOTALL)
+            mermaid_regex = re.compile(r'<(\w*?[^>]*)(><[^>]*?|[^>]*?)class="[^>\"]*(language-)?mermaid[^>\"]*">(<[^>]*?>)?(?P<code>.*?)(<\/[^>]*?>)?<\/\1>', flags=re.DOTALL)
             mermaid_matches = mermaid_regex.finditer(html)
 
             i = 0

--- a/mkdocs_with_pdf/options.py
+++ b/mkdocs_with_pdf/options.py
@@ -42,6 +42,7 @@ class Options(object):
         ('two_columns_level', config_options.Type(int, default=0)),
 
         ('render_js', config_options.Type(bool, default=False)),
+        ('mermaid_args', config_options.Type(str, default="-b transparent -t dark --scale 4 --quiet")),
         ('headless_chrome_path',
             config_options.Type(str, default='chromium-browser')),
         ('relaxedjs_path',
@@ -96,7 +97,7 @@ class Options(object):
         self.js_renderer = None
         if local_config['render_js']:
             self.js_renderer = HeadlessChromeDriver.setup(
-                local_config['headless_chrome_path'], logger)
+                local_config['headless_chrome_path'], local_config['mermaid_args'], logger)
 
         self.relaxed_js = RelaxedJSRenderer.setup(
             local_config['relaxedjs_path'], logger)


### PR DESCRIPTION
* Added option 'mermaid_args' to be able to specify arguments sent to mermaid-cli.
* Expanded mermaid HTML element detection. Now accepts any HTML element with a 'mermaid' or 'language-mermaid' class and at most one child HTML element.
    * `<pre class="mermaid">`
    * `<code class="mermaid"><pre>`
    * `<div class="mermaid">`
* Suppress mmdc sub-process chatter when using '--quiet'