### PR TITLE
Workaround for RelaxedJS '--build-once' not working

### DIFF
--- a/mkdocs_with_pdf/drivers/relaxedjs.py
+++ b/mkdocs_with_pdf/drivers/relaxedjs.py
@@ -42,3 +42,7 @@ class RelaxedJSRenderer(object):
                         self._logger.info(f"  {log}")
                     if proc.poll() is not None:
                         break
+                    # workaround for '--build-once' not working
+                    if log.find("Now idle and waiting for file changes") > -1:
+                        proc.kill()
+                        break


### PR DESCRIPTION
Kill the RelaxedJS process when it becomes idle to allow PDF build process to continue.