### PR TITLE
Fix: mkdocs-material custom checkbox overlap, ordered list alignment and blockquote

### DIFF
--- a/mkdocs_with_pdf/themes/material.scss
+++ b/mkdocs_with_pdf/themes/material.scss
@@ -1,4 +1,5 @@
-.md-typeset > ul {
+.md-typeset > ul,
+.md-typeset > ol {
   margin-left: 0rem !important;
 }
 .md-typeset ul li,
@@ -127,5 +128,10 @@
         display: inline-block;
       }
     }
+  }
+
+  // Task lists
+  .task-list-indicator:before {
+    left: -1.5em
   }
 }

--- a/mkdocs_with_pdf/themes/material.scss
+++ b/mkdocs_with_pdf/themes/material.scss
@@ -134,4 +134,10 @@
   .task-list-indicator:before {
     left: -1.5em
   }
+
+  // Blockquotes
+  blockquote {
+    border-left: .2rem solid #a9a9a9;
+    padding-left: .6rem;
+  }
 }


### PR DESCRIPTION
`orzih/mkdocs-with-pdf` is not maintained, so I am using this project. 

## Problem

With the mkdocs-material theme,

- Ordered list (`<ol>`) alignments differ from unordered list (`<ul>`) alignments, resulting in misalignment.
- Task list indicator icons overlap with text.

### v0.9.4

<img width="891" alt="current" src="https://github.com/user-attachments/assets/a2094d5b-fb79-433c-9a1c-d6457208a4a9" />

### Fix

<img width="903" alt="fix" src="https://github.com/user-attachments/assets/4f14fc98-8518-4c10-8376-54b0f049f25b" />

## Code

### mkdocs.yml

```yaml
site_name: My Docs
theme:
  name: material

markdown_extensions:
  - def_list
  - pymdownx.tasklist:
      custom_checkbox: true

plugins:
  - with-pdf:
```

### docs/index.md

```md
# list

## Unordered lists

- Nulla et rhoncus turpis. Mauris ultricies elementum leo. Duis efficitur
  accumsan nibh eu mattis. Vivamus tempus velit eros, porttitor placerat nibh
  lacinia sed. Aenean in finibus diam.

    * Duis mollis est eget nibh volutpat, fermentum aliquet dui mollis.
    * Nam vulputate tincidunt fringilla.
    * Nullam dignissim ultrices urna non auctor.

## Ordered lists

1.  Vivamus id mi enim. Integer id turpis sapien. Ut condimentum lobortis
    sagittis. Aliquam purus tellus, faucibus eget urna at, iaculis venenatis
    nulla. Vivamus a pharetra leo.

    1.  Vivamus venenatis porttitor tortor sit amet rutrum. Pellentesque aliquet
        quam enim, eu volutpat urna rutrum a. Nam vehicula nunc mauris, a
        ultricies libero efficitur sed.

    2.  Morbi eget dapibus felis. Vivamus venenatis porttitor tortor sit amet
        rutrum. Pellentesque aliquet quam enim, eu volutpat urna rutrum a.

        1.  Mauris dictum mi lacus
        2.  Ut sit amet placerat ante
        3.  Suspendisse ac eros arcu

## task lists

- [x] Lorem ipsum dolor sit amet, consectetur adipiscing elit
- [ ] Vestibulum convallis sit amet nisi a tincidunt
    * [x] In hac habitasse platea dictumst
    * [x] In scelerisque nibh non dolor mollis congue sed et metus
    * [ ] Praesent sed risus massa
- [ ] Aenean pretium efficitur erat, donec pharetra, ligula non scelerisque
```

## Environment

macOS 15.3.1 + Python 3.12.9

```text
$ pip freeze
babel==2.17.0
beautifulsoup4==4.13.3
Brotli==1.1.0
certifi==2025.1.31
cffi==1.17.1
charset-normalizer==3.4.1
click==8.1.8
colorama==0.4.6
cssselect2==0.7.0
fonttools==4.56.0
ghp-import==2.1.0
idna==3.10
Jinja2==3.1.5
libsass==0.23.0
Markdown==3.7
MarkupSafe==3.0.2
mergedeep==1.3.4
mkdocs==1.6.1
mkdocs-get-deps==0.2.0
mkdocs-material==9.6.5
mkdocs-material-extensions==1.3.1
mkdocs-with-pdf @ file:///Users/hideyuki/Workspaces/github.com/hkato/mkdocs-to-pdf
packaging==24.2
paginate==0.5.7
pathspec==0.12.1
pillow==11.1.0
platformdirs==4.3.6
pycparser==2.22
pydyf==0.11.0
Pygments==2.19.1
pymdown-extensions==10.14.3
pyphen==0.17.2
python-dateutil==2.9.0.post0
PyYAML==6.0.2
pyyaml_env_tag==0.1
regex==2024.11.6
requests==2.32.3
six==1.17.0
soupsieve==2.6
tinycss2==1.4.0
tinyhtml5==2.0.0
typing_extensions==4.12.2
urllib3==2.3.0
watchdog==6.0.0
weasyprint==64.1
webencodings==0.5.1
zopfli==0.2.3.post1
```

I also checked the Docker image `squidfunk/mkdocs-material:9.6.5` with `git+https://github.com/domWalters/mkdocs-to-pdf.git@v0.9.4` installed.
