### PR TITLE
update: fix repo icon and update logo icon(PDF)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,8 @@ theme:
     text: Roboto
     code: Roboto Mono
   icon:
-    repo: fontawesome/brands/gitlab
+    logo: fontawesome/solid/file-pdf
+    repo: fontawesome/brands/github
   name: material
   palette:
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
@domWalters 

How about these changes?

[Document page](https://mkdocs-to-pdf.readthedocs.io/en/latest/)

### Fix

GitLab -> GitHub

<img width="282" alt="スクリーンショット 2025-03-26 19 35 41" src="https://github.com/user-attachments/assets/997979df-4b3a-4067-9ad3-933b2a3be767" />
<img width="284" alt="スクリーンショット 2025-03-26 19 35 55" src="https://github.com/user-attachments/assets/c74ec181-a6c8-4341-82e7-231d73661e62" />

### Update

default -> FontAwsome PDF
 
<img width="218" alt="スクリーンショット 2025-03-26 19 34 54" src="https://github.com/user-attachments/assets/7a77ba11-5a60-4c08-9ad1-84d84fffaa37" />
<img width="222" alt="スクリーンショット 2025-03-26 19 35 10" src="https://github.com/user-attachments/assets/af38a055-2b71-4f19-894d-79f2d1b4a493" />
