### PR TITLE
Update usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,20 @@ following message at the end of your build output:
 
 ## Options
 
+### Download Link
+
+#### `download_link`
+
+Where to position the PDF download link/image. Can be either at the `header` or the `footer`.
+
+Does not have a default; must be set.
+
+```yaml
+plugins:
+    - to-pdf:
+        download_link: header
+```
+
 ### Headers and Footers
 
 #### `author`


### PR DESCRIPTION
I noticed that, by default, the link to download the PDF is not displayed. The `download_link` option must be explicitly set to either header or footer (which is not mentioned in usage).

I've added a description to clarify this behavior.