### PR TITLE
fix AttributeError caused by unset `self._cover_title` when `cover` is False

### DIFF
--- a/src/mkdocs_to_pdf/options.py
+++ b/src/mkdocs_to_pdf/options.py
@@ -71,6 +71,8 @@ class Options(object):
         self.cover = local_config['cover']
         self.back_cover = local_config['back_cover']
         self._cover_title = ""
+        self._cover_subtitle = ""
+        self._cover_logo = ""
         if self.cover or self.back_cover:
             self._cover_title = local_config['cover_title'] \
                 if local_config['cover_title'] else config['site_name']

--- a/src/mkdocs_to_pdf/options.py
+++ b/src/mkdocs_to_pdf/options.py
@@ -70,6 +70,7 @@ class Options(object):
         # Cover
         self.cover = local_config['cover']
         self.back_cover = local_config['back_cover']
+        self._cover_title = ""
         if self.cover or self.back_cover:
             self._cover_title = local_config['cover_title'] \
                 if local_config['cover_title'] else config['site_name']


### PR DESCRIPTION
When the `style_for_print` function is called, the `cover_title` property of the `Options` class is accessed, which in turn accesses the `_cover_title` attribute of the instance. This attribute was only available when `cover` is True, but the `style_for_print` function is also called when `cover` is False. This causes the error `AttributeError: 'Options' object has no attribute '_cover_title'. Did you mean: 'cover_title'?`

The solution is to init the attribute with an empty string.

Full Stacktrace:
```
Traceback (most recent call last):
  File "/home/user/project/.venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs/commands/build.py", line 347, in build
    config.plugins.on_post_build(config=config)
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 602, in on_post_build
    return self.run_event('post_build', config=config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs/plugins.py", line 568, in run_event
    result = method(**kwargs)
             ^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs_to_pdf/plugin.py", line 134, in on_post_build
    self.generator.on_post_build(config, self.config['output_path'])
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs_to_pdf/generator.py", line 122, in on_post_build
    add_stylesheet(style_for_print(self._options))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs_to_pdf/styles/__init__.py", line 28, in style_for_print
    title '{_css_escape(options.cover_title)}';
                        ^^^^^^^^^^^^^^^^^^^
  File "/home/user/project/.venv/lib/python3.12/site-packages/mkdocs_to_pdf/options.py", line 135, in cover_title
    return self._cover_title
           ^^^^^^^^^^^^^^^^^
AttributeError: 'Options' object has no attribute '_cover_title'. Did you mean: 'cover_title'
```