### PR TITLE
New option: debug_html_path

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,3 +229,14 @@ plugins:
       debug_html: true
 ```
 
+#### `debug_html_path`
+
+When `debug_html` is set to true, `debug_html_path` can write the html output to a given file instead of `stdout`. This output html file can then be directly opened in a web browser for easier debugging.
+
+``` yaml
+plugins:
+  - to-pdf:
+      debug_html: true
+      debug_html_file: out.html
+```
+

--- a/src/mkdocs_to_pdf/generator.py
+++ b/src/mkdocs_to_pdf/generator.py
@@ -148,7 +148,11 @@ class Generator(object):
         html_string = self._options.hook.pre_pdf_render(html_string)
 
         if self._options.debug_html:
-            print(f'{html_string}')
+            if self._options.debug_html_path == '':
+                print(f'{html_string}')
+            else:
+                with open(self._options.debug_html_path, 'wt') as f:
+                    f.write(html_string)
 
         self.logger.info("Rendering for PDF.")
 

--- a/src/mkdocs_to_pdf/options.py
+++ b/src/mkdocs_to_pdf/options.py
@@ -15,6 +15,7 @@ class Options(object):
 
         ('verbose', config_options.Type(bool, default=False)),
         ('debug_html', config_options.Type(bool, default=False)),
+        ('debug_html_path', config_options.Type(str, default='')),
         ('show_anchors', config_options.Type(bool, default=False)),
 
         ('output_path', config_options.Type(str, default="pdf/document.pdf")),
@@ -53,6 +54,7 @@ class Options(object):
 
         self.verbose = local_config['verbose']
         self.debug_html = local_config['debug_html']
+        self.debug_html_path = local_config['debug_html_path']
         self.show_anchors = local_config['show_anchors']
 
         self.output_path = local_config.get('output_path', None)


### PR DESCRIPTION
To save the `debug_html` output to a filepath instead of just printing it to stdout with other mkdocs messages. The output file can then be directly opened in a web browser for debugging.