### PR TITLE
remove h1 of the first child page of a url-less section

### DIFF
--- a/src/mkdocs_to_pdf/generator.py
+++ b/src/mkdocs_to_pdf/generator.py
@@ -47,6 +47,17 @@ class Generator(object):
         self._options.logger.debug(
             f'Exclude page patterns: {self._exclude_page_patterns}')
 
+    def _is_first_child_of_url_less_section(self, nav_items, page):
+        """Recursively search for the page in the nav."""
+        for item in nav_items:
+            if item.is_section and not hasattr(item, 'url') and item.children:
+                if item.children[0] == page:
+                    return True
+                # Recurse into children of the section
+                if self._is_first_child_of_url_less_section(item.children, page):
+                    return True
+        return False
+
     def on_nav(self, nav):
         """ on_nav """
         self._nav = nav
@@ -55,6 +66,14 @@ class Generator(object):
 
     def on_post_page(self, output_content: str, page, pdf_path: str) -> str:
         """ on_post_page """
+
+        if self._is_first_child_of_url_less_section(self._nav, page):
+            self._options.logger.info(f"Removing h1 from '{page.title}' as it is the first child of a URL-less section.")
+            soup = BeautifulSoup(output_content, 'html.parser')
+            h1 = soup.find('h1')
+            if h1:
+                h1.decompose()
+                output_content = str(soup)
 
         def is_excluded(url: str) -> bool:
             for p in self._exclude_page_patterns:


### PR DESCRIPTION
To ensure compatibility with mkdocs-material.

Fixes the following case:

nav:
  - intro.md
  - 'Section A':
    - section_a/index.md
    - section_a/chapter1.md
    - section_a/chapter2.md
    - 'Subsection X':
      - section_a/subsection_x/index.md
      - section_a/subsection_x/chapter1.md

With mkdocs-material, the main heading (e.g. "# Section A") in section_a/index.md and in section_a/subsection_x/index.md is hidden. This patch hides it in the pdf output too.