### PR TITLE
new option: weasyprint_log_path

### DIFF
--- a/src/mkdocs_to_pdf/options.py
+++ b/src/mkdocs_to_pdf/options.py
@@ -20,6 +20,7 @@ class Options(object):
         ('output_path', config_options.Type(str, default="pdf/document.pdf")),
         ('html_path', config_options.Type(str, default=None)),
         ('theme_handler_path', config_options.Type(str, default=None)),
+        ('weasyprint_log_path', config_options.Type(str, default='')),
 
         ('author', config_options.Type(str, default='')),
         ('copyright', config_options.Type(str, default='')),
@@ -59,6 +60,7 @@ class Options(object):
         self.output_path = local_config['output_path']
         self.html_path = local_config.get('html_path', None)
         self.theme_handler_path = local_config.get('theme_handler_path', None)
+        self.weasyprint_log_path = local_config['weasyprint_log_path']
 
         # Author and Copyright
         self._author = local_config['author'] or config['site_author'] or ''

--- a/src/mkdocs_to_pdf/plugin.py
+++ b/src/mkdocs_to_pdf/plugin.py
@@ -88,6 +88,12 @@ class WithPdfPlugin(BasePlugin):
         else:
             LOGGER.setLevel(logging.ERROR)
 
+        if self._options.weasyprint_log_path:
+            open(self._options.weasyprint_log_path, 'w').close() # Logger appends to the file by default so we have to clear it explicitly
+            handler = logging.FileHandler(self._options.weasyprint_log_path)
+            handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+            LOGGER.addHandler(handler)
+
         if self._options.strict:
             self._error_counter = _ErrorAndWarningCountFilter()
             LOGGER.addFilter(self._error_counter)


### PR DESCRIPTION
For setting an output path for the weasyprint log for easier debugging of weasyprint issues.

Although there was already the following code in plugin.py:
```
from weasyprint.logger import LOGGER
if self._options.verbose:
    LOGGER.setLevel(logging.DEBUG)
    self._logger.setLevel(logging.DEBUG)
else:
    LOGGER.setLevel(logging.ERROR)
```
If I understand it correctly, this is supposed to show the weasyprint log in the mkdocs output when `verbose: true`, but I don't see it there. That's why I made this new option for writing it to a separate file.