### PR TITLE
Allow html tags in TOC items and in section titles

### DIFF
--- a/src/mkdocs_to_pdf/generator.py
+++ b/src/mkdocs_to_pdf/generator.py
@@ -242,7 +242,7 @@ class Generator(object):
 
             page_path = self._page_path_for_id(page)
             h1 = soup.new_tag('h1', id=f'{page_path}')
-            h1.append(str(page.title))
+            h1.append(BeautifulSoup(str(page.title), 'html.parser'))
             elem.insert(0, h1)
             return elem
 

--- a/src/mkdocs_to_pdf/toc.py
+++ b/src/mkdocs_to_pdf/toc.py
@@ -1,8 +1,7 @@
-from bs4 import PageElement, Tag
+from bs4 import PageElement, Tag, BeautifulSoup
 
 from .options import Options
 from .utils.soup_util import clone_element
-
 
 def make_indexes(soup: PageElement, options: Options) -> None:
     """ Generate ordered chapter number and TOC of document.
@@ -31,11 +30,7 @@ def make_indexes(soup: PageElement, options: Options) -> None:
         li = soup.new_tag('li')
         ref = h.get('id', '')
         a = soup.new_tag('a', href=f'#{ref}')
-        for el in h.contents:
-            if el.name == 'a':
-                a.append(el.contents[0])
-            else:
-                a.append(clone_element(el))
+        a.append(BeautifulSoup(h.decode_contents(), 'html.parser'))
         li.append(a)
         options.logger.debug(f"| [{h.get_text(separator=' ')}]({ref})")
         return li


### PR DESCRIPTION
In my documentation project I have a "PRO" badge generated by a macro `{{ _PRO }}` used in nav section titles, adding `<img .../>` to those titles. But mkdocs-to-html escaped html tags in titles so they were shown as plaintext html. This patch makes them rendered correctly, similarly to the normal mkdocs-material html output.

Here is an example of the image badge in a section title in TOC:
<img width="699" height="132" alt="image" src="https://github.com/user-attachments/assets/a53f52c9-b349-4607-bcfd-61f60405e750" />
